### PR TITLE
Change es version to 1.0.0.RC1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <version>1.2.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Elasticsearch Solr API</name>
-    <description>Use Solr clients/tools with ElasticSearch</description>
+    <description>Use Solr clients/tools with Elasticsearch</description>
     <inceptionYear>2011</inceptionYear>
     <url>https://github.com/codelibs/elasticsearch-solr-api</url>
     <licenses>
@@ -27,8 +27,8 @@
         <version>7</version>
     </parent>
     <properties>
-        <elasticsearch.version>0.90.5</elasticsearch.version>
-        <solr.version>4.4.0</solr.version>
+        <elasticsearch.version>1.0.0.RC1</elasticsearch.version>
+        <solr.version>4.6.0</solr.version>
     </properties>
     <developers>
         <developer>

--- a/src/main/java/org/elasticsearch/rest/ExtendedRestRequest.java
+++ b/src/main/java/org/elasticsearch/rest/ExtendedRestRequest.java
@@ -9,7 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.elasticsearch.ElasticSearchIllegalArgumentException;
+import org.elasticsearch.ElasticsearchIllegalArgumentException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.TimeValue;
@@ -21,7 +21,7 @@ import static org.elasticsearch.common.unit.TimeValue.*;
  * @author shinsuke
  * 
  */
-public class ExtendedRestRequest implements RestRequest {
+public class ExtendedRestRequest extends RestRequest {
     private RestRequest parent;
 
     private volatile Map<String, List<String>> paramMap;
@@ -131,11 +131,6 @@ public class ExtendedRestRequest implements RestRequest {
     }
 
     @Override
-    public String path() {
-        return parent.path();
-    }
-
-    @Override
     public boolean hasContent() {
         return parent.hasContent();
     }
@@ -153,6 +148,11 @@ public class ExtendedRestRequest implements RestRequest {
     @Override
     public String header(final String name) {
         return parent.header(name);
+    }
+
+    @Override
+    public Iterable<Map.Entry<String, String>> headers() {
+        return parent.headers();
     }
 
     @Override
@@ -185,7 +185,7 @@ public class ExtendedRestRequest implements RestRequest {
         try {
             return Float.parseFloat(value);
         } catch (final NumberFormatException e) {
-            throw new ElasticSearchIllegalArgumentException(
+            throw new ElasticsearchIllegalArgumentException(
                     "Failed to parse float parameter [" + key
                             + "] with value [" + value + "]", e);
         }
@@ -201,7 +201,7 @@ public class ExtendedRestRequest implements RestRequest {
         try {
             return Integer.parseInt(value);
         } catch (final NumberFormatException e) {
-            throw new ElasticSearchIllegalArgumentException(
+            throw new ElasticsearchIllegalArgumentException(
                     "Failed to parse int parameter [" + key + "] with value ["
                             + value + "]", e);
         }
@@ -217,7 +217,7 @@ public class ExtendedRestRequest implements RestRequest {
         try {
             return Long.parseLong(value);
         } catch (final NumberFormatException e) {
-            throw new ElasticSearchIllegalArgumentException(
+            throw new ElasticsearchIllegalArgumentException(
                     "Failed to parse long parameter [" + key + "] with value ["
                             + value + "]", e);
         }
@@ -233,7 +233,7 @@ public class ExtendedRestRequest implements RestRequest {
         try {
             return Boolean.parseBoolean(value);
         } catch (final NumberFormatException e) {
-            throw new ElasticSearchIllegalArgumentException(
+            throw new ElasticsearchIllegalArgumentException(
                     "Failed to parse boolean parameter [" + key
                             + "] with value [" + value + "]", e);
         }

--- a/src/main/java/org/elasticsearch/rest/SolrSearchRestAction.java
+++ b/src/main/java/org/elasticsearch/rest/SolrSearchRestAction.java
@@ -223,7 +223,7 @@ public class SolrSearchRestAction extends BaseRestHandler {
                 filterBuilder = queryFilter(queryBuilder);
             }
 
-            searchSourceBuilder.filter(filterBuilder);
+            searchSourceBuilder.postFilter(filterBuilder);
         }
 
         // handle highlighting

--- a/src/main/java/org/elasticsearch/rest/SolrUpdateRestAction.java
+++ b/src/main/java/org/elasticsearch/rest/SolrUpdateRestAction.java
@@ -26,7 +26,7 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.SolrInputField;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
-import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.SolrPluginConstants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -101,7 +101,7 @@ public class SolrUpdateRestAction extends BaseRestHandler {
         optimizeAsOptimize = settings.getAsBoolean("solr.optimizeAsOptimize",
                 true);
         logger.info("Solr input document id's will " + (hashIds ? "" : "not ")
-                + "be hashed to created ElasticSearch document id's");
+                + "be hashed to created Elasticsearch document id's");
 
         defaultIndexName = settings.get("solr.default.index",
                 SolrPluginConstants.DEFAULT_INDEX_NAME);
@@ -558,7 +558,7 @@ public class SolrUpdateRestAction extends BaseRestHandler {
         // create the delete request object
         final DeleteByQueryRequest deleteRequest = Requests
                 .deleteByQueryRequest(index);
-        deleteRequest.query("{\"query_string\":{\"query\":\"" + query + "\"}}");
+        deleteRequest.source("{\"query_string\":{\"query\":\"" + query + "\"}}");
 
         deleteRequest.routing(request.param("routing"));
 
@@ -602,7 +602,6 @@ public class SolrUpdateRestAction extends BaseRestHandler {
         // indexRequest.versionType(VersionType.fromString(request.param("version_type"),
         // indexRequest.versionType()));
 
-        indexRequest.percolate(request.param("percolate", null));
         indexRequest.opType(IndexRequest.OpType.INDEX);
 
         // TODO: force creation of index, do we need it?
@@ -696,7 +695,7 @@ public class SolrUpdateRestAction extends BaseRestHandler {
             final char[] encodeHex = Hex.encodeHex(digest);
             return String.valueOf(encodeHex);
         } catch (final NoSuchAlgorithmException e) {
-            throw new ElasticSearchException("Failed to encode " + input, e);
+            throw new ElasticsearchException("Failed to encode " + input, e);
         }
     }
 

--- a/src/main/java/org/elasticsearch/solr/SolrResponseUtils.java
+++ b/src/main/java/org/elasticsearch/solr/SolrResponseUtils.java
@@ -19,7 +19,7 @@ import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.util.JavaBinCodec;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
-import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.SolrPluginConstants;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.logging.ESLogger;
@@ -66,7 +66,7 @@ public class SolrResponseUtils {
                 return new SimpleDateFormat(YYYY_MM_DD_T_HH_MM_SS_Z)
                         .parse(value);
             } catch (final ParseException e1) {
-                throw new ElasticSearchException("Could not parse " + value, e);
+                throw new ElasticsearchException("Could not parse " + value, e);
             }
         }
     }
@@ -409,7 +409,7 @@ public class SolrResponseUtils {
                 }
             });
         } catch (final UnsupportedEncodingException e) {
-            throw new ElasticSearchException("Unsupported encoding.", e);
+            throw new ElasticsearchException("Unsupported encoding.", e);
         }
     }
 }


### PR DESCRIPTION
- Move RestRequest to be an abstract class https://github.com/elasticsearch/elasticsearch/issues/4683
- Change the version of es to 1.0.0.RC1
- Related DateFieldMapper https://github.com/elasticsearch/elasticsearch/issues/3806 , https://github.com/elasticsearch/elasticsearch/issues/4560 , https://github.com/elasticsearch/elasticsearch/issues/4079 , https://github.com/elasticsearch/elasticsearch/issues/4117 , https://github.com/elasticsearch/elasticsearch/issues/4521
- Redesigned the percolator engine https://github.com/elasticsearch/elasticsearch/issues/3173
